### PR TITLE
Fix compiler error when GLTFAST_SAFE is enabled

### DIFF
--- a/Runtime/Scripts/Schema/Root.cs
+++ b/Runtime/Scripts/Schema/Root.cs
@@ -571,11 +571,11 @@ namespace GLTFast.Schema
             }
 
 #if GLTFAST_SAFE
-            if (accessors != null) {
-                for (var i = 0; i < accessors.Length; i++) {
+            if (Accessors != null) {
+                for (var i = 0; i < Accessors.Count; i++) {
                     var sparse = fakeRoot.accessors[i].sparse;
                     if (sparse?.indices == null || sparse.values == null) {
-                        accessors[i].sparse = null;
+                        Accessors[i].UnsetSparse();
                     }
                 }
             }


### PR DESCRIPTION
Fix a compiler error when the `GLTFAST_SAFE` preprocessor directive is enabled. This issue appears to have been introduced with 0c71cee.