### PR TITLE
Fix NullReferenceException when export fails without a logger

### DIFF
--- a/Runtime/Scripts/Export/GltfWriter.cs
+++ b/Runtime/Scripts/Export/GltfWriter.cs
@@ -569,7 +569,7 @@ namespace GLTFast.Export
 
             if (m_Settings.Format != GltfFormat.Binary || GetFinalImageDestination() == ImageDestination.SeparateFile)
             {
-                m_Logger.Error(LogCode.None, "Save to Stream currently only works for self-contained glTF-Binary");
+                m_Logger?.Error(LogCode.None, "Save to Stream currently only works for self-contained glTF-Binary");
                 return false;
             }
 


### PR DESCRIPTION
Added missing null check

I've originally opened a PR in https://github.com/atteneder/glTFast/pull/647, but I'm reopening it here since it was suggested to do so in https://github.com/atteneder/glTFast/issues/650#issuecomment-1757855125.