### PR TITLE
Escape names of nodes and meshes

### DIFF
--- a/Runtime/Scripts/Export/GltfWriter.cs
+++ b/Runtime/Scripts/Export/GltfWriter.cs
@@ -2105,7 +2105,7 @@ namespace GLTFast.Export
         {
             var node = new Node
             {
-                name = name,
+                name = EscapeJson(name),
             };
             if (translation.HasValue && !translation.Equals(float3.zero))
             {
@@ -2146,7 +2146,7 @@ namespace GLTFast.Export
 
             var mesh = new Mesh
             {
-                name = uMesh.name
+                name = EscapeJson(uMesh.name)
             };
             m_Meshes = m_Meshes ?? new List<Mesh>();
             m_UnityMeshes = m_UnityMeshes ?? new List<UnityEngine.Mesh>();
@@ -2174,6 +2174,14 @@ namespace GLTFast.Export
                 return bufferViewId;
             }
         }
+
+        static string EscapeJson(string s)
+            => s?.Replace("\\", "\\\\")
+                 .Replace("\f", "\\f")
+                 .Replace("\n", "\\n")
+                 .Replace("\r", "\\r")
+                 .Replace("\t", "\\t")
+                 .Replace("\"", "\\\"");
 
         Stream CertifyBuffer()
         {


### PR DESCRIPTION
Meshes and GameObjects can have characters in their names that need to be escaped in JSON strings, e.g. backslashes. Currently this creates invalid JSON when such a GameObject/Mesh is exported. The exported file can not be imported again with this plugin and external tools also fail to open it (I've tested with Blender).

## How to reproduce

1. Place any model in your scene
2. Add a backslash to the game objects name
3. Export the model
4. Try importing the exported file again or try to open it in Blender

## Changes

This PR makes sure such characters are properly escaped in mesh and node names when exporting. Materials and images can not have these special characters in their names because Unity does not allow them in asset names, so I left them as is. Let me know in case you want them to be escaped as well and I'll add a commit.