### PR TITLE
Export non-readable meshes

### DIFF
--- a/Runtime/Scripts/Export/GltfWriter.cs
+++ b/Runtime/Scripts/Export/GltfWriter.cs
@@ -932,7 +932,58 @@ namespace GLTFast.Export
             }
             var tasks = m_Settings.Deterministic ? null : new List<Task>(m_Meshes.Count);
 
-            var meshDataArray = UnityEngine.Mesh.AcquireReadOnlyMeshData(m_UnityMeshes);
+            using var meshDataArray = UnityEngine.Mesh.AllocateWritableMeshData(m_UnityMeshes.Count);
+            
+            for (int i = 0; i < m_UnityMeshes.Count; i++)
+            {
+                var mesh = m_UnityMeshes[i];
+                var meshData = meshDataArray[i];
+                
+                mesh.indexBufferTarget |= GraphicsBuffer.Target.Raw;
+                using var indexBuf = mesh.GetIndexBuffer();
+                var requestIndexBuf = AsyncGPUReadback.Request(indexBuf);
+
+                mesh.vertexBufferTarget |= GraphicsBuffer.Target.Raw;
+                meshData.SetVertexBufferParams(mesh.vertexCount, mesh.GetVertexAttributes());
+
+                for (int bufIndex = 0; bufIndex < mesh.vertexBufferCount; bufIndex++)
+                {
+                    using var vertexBuf = mesh.GetVertexBuffer(bufIndex);
+                    var requestVertexBuf = AsyncGPUReadback.Request(vertexBuf);
+                    requestVertexBuf.WaitForCompletion();
+                    if (requestVertexBuf.hasError)
+                        return false;
+                    
+                    using var nativeVertices = requestVertexBuf.GetData<byte>();
+                    var pos = meshData.GetVertexData<byte>(bufIndex);
+                    nativeVertices.CopyTo(pos);
+                }
+
+                requestIndexBuf.WaitForCompletion();
+                if (requestIndexBuf.hasError)
+                    return false;
+                
+                using var nativeIndices = requestIndexBuf.GetData<ushort>();
+                meshData.SetIndexBufferParams(indexBuf.count, mesh.indexFormat);
+                var ind = meshData.GetIndexData<ushort>();
+                nativeIndices.CopyTo(ind);
+                
+                meshData.subMeshCount = mesh.subMeshCount;
+                for (int j = 0; j < meshData.subMeshCount; j++)
+                {
+                    var orig = mesh.GetSubMesh(j);
+                    var descr = new SubMeshDescriptor(orig.indexStart, orig.indexCount, orig.topology);
+                    // The submeshes come directly from the mesh, so they must 
+                    // be valid. Disable checks for optimized performance.
+                    var flags 
+                        = MeshUpdateFlags.DontValidateIndices
+                        | MeshUpdateFlags.DontResetBoneBounds
+                        | MeshUpdateFlags.DontNotifyMeshUsers
+                        | MeshUpdateFlags.DontRecalculateBounds;
+                    meshData.SetSubMesh(j, descr, flags);
+                }
+            }
+
             Profiler.EndSample();
             for (var meshId = 0; meshId < m_Meshes.Count; meshId++)
             {
@@ -963,7 +1014,6 @@ namespace GLTFast.Export
             {
                 await Task.WhenAll(tasks);
             }
-            meshDataArray.Dispose();
             return true;
         }
 
@@ -2124,14 +2174,6 @@ namespace GLTFast.Export
         int AddMesh(UnityEngine.Mesh uMesh)
         {
             int meshId;
-
-#if !UNITY_EDITOR
-            if (!uMesh.isReadable)
-            {
-                m_Logger?.Error(LogCode.MeshNotReadable, uMesh.name);
-                return -1;
-            }
-#endif
 
             if (m_UnityMeshes != null)
             {


### PR DESCRIPTION
## Description

This PR allows exporting meshes that have read/write set to disabled in the import settings.

## Implementation

When a mesh is not readable, it's data on the CPU can obviously not be accessed. However, it is possible to read the native buffer from the GPU by using the AsyncGPU API, as suggested by @atteneder.

## Issues

Fixes https://github.com/atteneder/glTFast/issues/503

## Testing

I've tested this with a many different assets in our internal workflow, which mostly involves exporting to Blender and Unity. I haven't found any issues so far. I've also run the export test from https://github.com/atteneder/glTFastTest and got the same results as the current main branch of this repository, with one exception: the _Quads_ test fails with this PR, but does not do so without it. The reason is that the buffer size changes with this PR. The exported glTF is fully intact though. I've tested it with Blender, Babylon.js, Cesium, Filament Three.js and with the runtime import of this plugin.