### PR TITLE
Fix calls to RenderMeshUtility.AddComponents to be compatible with com.unity.entities.graphics 1.2.0.

### DIFF
--- a/Runtime/Scripts/DOTS/EntityInstantiator.cs
+++ b/Runtime/Scripts/DOTS/EntityInstantiator.cs
@@ -273,7 +273,7 @@ namespace GLTFast {
                     MaterialMeshInfo.FromRenderMeshArrayIndices(
                         index,
                         0,
-                        (sbyte)index
+                        (ushort)index
                         )
                     );
 
@@ -381,7 +381,7 @@ namespace GLTFast {
                         m_EntityManager,
                         renderMeshDescription,
                         renderMeshArray,
-                        MaterialMeshInfo.FromRenderMeshArrayIndices(index, 0, (sbyte) index)
+                        MaterialMeshInfo.FromRenderMeshArrayIndices(index, 0, (ushort) index)
                     );
                 }
 


### PR DESCRIPTION
Without this change, `EntityInstantiator.cs` does not compile with `com.unity.entities.graphics=1.2.0`.
Though, with this change, it will most likely not compile with `com.unity.entities.graphics<1.2.0`.