### PR TITLE
Primitive Mode TRIANGLE_STRIP and TRIANGLE_FAN implementation, LINE_LOOP render fix

### DIFF
--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -3664,7 +3664,8 @@ namespace GLTFast
                     resultHandle = default;
                     break;
                 case DrawMode.TriangleStrip:
-                    indices = new int[(oldIndices.Length - 2) * 3];
+                    int triangleStripTriangleCount = oldIndices.Length - 2;
+                    indices = new int[triangleStripTriangleCount * 3];
                     resultHandle = GCHandle.Alloc(indices, GCHandleType.Pinned);
                     //RecalculateIndicesTriangleStripJob
                     var triangleStripJob = new RecalculateIndicesForTriangleStripJob();
@@ -3676,10 +3677,11 @@ namespace GLTFast
                     {
                         triangleStripJob.input = (int*)inp;
                     }
-                    jobHandle = triangleStripJob.Schedule(oldIndices.Length, DefaultBatchCount);
+                    jobHandle = triangleStripJob.Schedule(triangleStripTriangleCount, DefaultBatchCount);
                     break;
                 case DrawMode.TriangleFan:
-                    indices = new int[(oldIndices.Length - 2) * 3];
+                    int triangleFanTriangleCount = oldIndices.Length - 2;
+                    indices = new int[triangleFanTriangleCount * 3];
                     resultHandle = GCHandle.Alloc(indices, GCHandleType.Pinned);
                     //RecalculateIndicesTriangleFanJob
                     var triangleFanJob = new RecalculateIndicesForTriangleFanJob();
@@ -3691,7 +3693,7 @@ namespace GLTFast
                     {
                         triangleFanJob.input = (int*)inp;
                     }
-                    jobHandle = triangleFanJob.Schedule(oldIndices.Length, DefaultBatchCount);
+                    jobHandle = triangleFanJob.Schedule(triangleFanTriangleCount, DefaultBatchCount);
                     break;
                 default:
                     indices = oldIndices;

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -3052,11 +3052,7 @@ namespace GLTFast
                     var att = primitive.attributes;
                     if (primitive.indices >= 0)
                     {
-                        var usage = (
-                            primitive.mode == DrawMode.Triangles
-                            || primitive.mode == DrawMode.TriangleStrip
-                            || primitive.mode == DrawMode.TriangleFan
-                            )
+                        var usage = ( primitive.mode == DrawMode.Triangles )
                         ? AccessorUsage.IndexFlipped
                         : AccessorUsage.Index;
                         SetAccessorUsage(primitive.indices, isDraco ? AccessorUsage.Ignore : usage);
@@ -3606,30 +3602,36 @@ namespace GLTFast
                     c.topology = MeshTopology.Lines;
                     break;
                 case DrawMode.LineLoop:
-                    m_Logger?.Error(LogCode.PrimitiveModeUnsupported, primitive.mode.ToString());
                     c.topology = MeshTopology.LineStrip;
                     break;
                 case DrawMode.LineStrip:
                     c.topology = MeshTopology.LineStrip;
                     break;
                 case DrawMode.TriangleStrip:
+                    c.topology = MeshTopology.Triangles;
+                    break;
                 case DrawMode.TriangleFan:
+                    c.topology = MeshTopology.Triangles;
+                    break;
                 default:
                     m_Logger?.Error(LogCode.PrimitiveModeUnsupported, primitive.mode.ToString());
                     c.topology = MeshTopology.Triangles;
                     break;
             }
 
+            int[] indices;
             if (primitive.indices >= 0)
             {
-                c.SetIndices(subMesh, ((AccessorData<int>)m_AccessorData[primitive.indices]).data);
+                indices = ((AccessorData<int>)m_AccessorData[primitive.indices]).data;
+                RecalculateIndicesJob(primitive, indices, out indices, out c.jobHandle, out c.calculatedIndicesHandle);
             }
             else
             {
                 int vertexCount = gltf.Accessors[primitive.attributes.POSITION].count;
-                CalculateIndicesJob(primitive, vertexCount, c.topology, out var indices, out c.jobHandle, out c.calculatedIndicesHandle);
-                c.SetIndices(subMesh, indices);
+                CalculateIndicesJob(primitive, vertexCount, c.topology, out indices, out c.jobHandle, out c.calculatedIndicesHandle);
             }
+
+            c.SetIndices(subMesh, indices);
             Profiler.EndSample();
         }
 
@@ -3643,6 +3645,61 @@ namespace GLTFast
             c.StartDecode(buffer, dracoExt.attributes);
         }
 #endif
+
+        static unsafe void RecalculateIndicesJob (
+            MeshPrimitiveBase primitive,
+            int[] oldIndices,
+            out int[] indices,
+            out JobHandle jobHandle,
+            out GCHandle resultHandle
+            )
+        {
+            switch (primitive.mode)
+            {
+                case DrawMode.LineLoop:
+                    indices = new int[oldIndices.Length + 1];
+                    Array.Copy(oldIndices, indices, oldIndices.Length);
+                    indices[oldIndices.Length] = oldIndices[0];
+                    jobHandle = default;
+                    resultHandle = default;
+                    break;
+                case DrawMode.TriangleStrip:
+                    indices = new int[(oldIndices.Length - 2) * 3];
+                    resultHandle = GCHandle.Alloc(indices, GCHandleType.Pinned);
+                    //RecalculateIndicesTriangleStripJob
+                    var triangleStripJob = new RecalculateIndicesForTriangleStripJob();
+                    fixed (void* dst = &(indices[0]))
+                    {
+                        triangleStripJob.result = (int*)dst;
+                    }
+                    fixed (void* inp = &(oldIndices[0]))
+                    {
+                        triangleStripJob.input = (int*)inp;
+                    }
+                    jobHandle = triangleStripJob.Schedule(oldIndices.Length, DefaultBatchCount);
+                    break;
+                case DrawMode.TriangleFan:
+                    indices = new int[(oldIndices.Length - 2) * 3];
+                    resultHandle = GCHandle.Alloc(indices, GCHandleType.Pinned);
+                    //RecalculateIndicesTriangleFanJob
+                    var triangleFanJob = new RecalculateIndicesForTriangleFanJob();
+                    fixed (void* dst = &(indices[0]))
+                    {
+                        triangleFanJob.result = (int*)dst;
+                    }
+                    fixed (void* inp = &(oldIndices[0]))
+                    {
+                        triangleFanJob.input = (int*)inp;
+                    }
+                    jobHandle = triangleFanJob.Schedule(oldIndices.Length, DefaultBatchCount);
+                    break;
+                default:
+                    indices = oldIndices;
+                    jobHandle = default;
+                    resultHandle = default;
+                    break;
+            }
+        }
 
         static unsafe void CalculateIndicesJob(
             MeshPrimitiveBase primitive,
@@ -3659,28 +3716,47 @@ namespace GLTFast
             // extra index (first vertex again) for closing line loop
             indices = new int[vertexCount + (lineLoop ? 1 : 0)];
             resultHandle = GCHandle.Alloc(indices, GCHandleType.Pinned);
-            if (topology == MeshTopology.Triangles)
+            switch (primitive.mode)
             {
-                var job8 = new CreateIndicesInt32FlippedJob();
-                fixed (void* dst = &(indices[0]))
-                {
-                    job8.result = (int*)dst;
-                }
-                jobHandle = job8.Schedule(indices.Length, DefaultBatchCount);
-            }
-            else
-            {
-                var job8 = new CreateIndicesInt32Job();
-                if (lineLoop)
-                {
-                    // Set the last index to the first vertex
-                    indices[vertexCount] = 0;
-                }
-                fixed (void* dst = &(indices[0]))
-                {
-                    job8.result = (int*)dst;
-                }
-                jobHandle = job8.Schedule(vertexCount, DefaultBatchCount);
+                case DrawMode.Triangles:
+                    var flippedJob8 = new CreateIndicesInt32FlippedJob();
+                    fixed (void* dst = &(indices[0]))
+                    {
+                        flippedJob8.result = (int*)dst;
+                    }
+                    jobHandle = flippedJob8.Schedule(indices.Length, DefaultBatchCount);
+                    break;
+                case DrawMode.TriangleStrip:
+                    indices = new int[(indices.Length - 2) * 3];
+                    var triangleStripJob = new CreateIndicesForTriangleStripJob();
+                    fixed (void* dst = &(indices[0]))
+                    {
+                        triangleStripJob.result = (int*)dst;
+                    }
+                    jobHandle = triangleStripJob.Schedule(indices.Length, DefaultBatchCount);
+                    break;
+                case DrawMode.TriangleFan:
+                    indices = new int[(indices.Length - 2) * 3];
+                    var triangleFanJob = new CreateIndicesForTriangleFanJob();
+                    fixed (void* dst = &(indices[0]))
+                    {
+                        triangleFanJob.result = (int*)dst;
+                    }
+                    jobHandle = triangleFanJob.Schedule(indices.Length, DefaultBatchCount);
+                    break;
+                default:
+                    var job8 = new CreateIndicesInt32Job();
+                    if (lineLoop)
+                    {
+                        // Set the last index to the first vertex
+                        indices[vertexCount] = 0;
+                    }
+                    fixed (void* dst = &(indices[0]))
+                    {
+                        job8.result = (int*)dst;
+                    }
+                    jobHandle = job8.Schedule(vertexCount, DefaultBatchCount);
+                    break;
             }
             Profiler.EndSample();
         }

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -3667,7 +3667,6 @@ namespace GLTFast
                     int triangleStripTriangleCount = oldIndices.Length - 2;
                     indices = new int[triangleStripTriangleCount * 3];
                     resultHandle = GCHandle.Alloc(indices, GCHandleType.Pinned);
-                    //RecalculateIndicesTriangleStripJob
                     var triangleStripJob = new RecalculateIndicesForTriangleStripJob();
                     fixed (void* dst = &(indices[0]))
                     {
@@ -3683,7 +3682,6 @@ namespace GLTFast
                     int triangleFanTriangleCount = oldIndices.Length - 2;
                     indices = new int[triangleFanTriangleCount * 3];
                     resultHandle = GCHandle.Alloc(indices, GCHandleType.Pinned);
-                    //RecalculateIndicesTriangleFanJob
                     var triangleFanJob = new RecalculateIndicesForTriangleFanJob();
                     fixed (void* dst = &(indices[0]))
                     {

--- a/Runtime/Scripts/Jobs.cs
+++ b/Runtime/Scripts/Jobs.cs
@@ -327,6 +327,121 @@ namespace GLTFast.Jobs
     }
 
     [BurstCompile]
+    unsafe struct CreateIndicesForTriangleStripJob : IJobParallelFor
+    {
+
+        [ReadOnly]
+        [NativeDisableUnsafePtrRestriction]
+        public int* result;
+
+        public void Execute(int i)
+        {
+            // Source https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html
+            // Triangle Strips
+            // One triangle primitive is defined by each vertex and the two vertices that follow it, according to the equation:
+            // pi = { vi, vi + (1 + i % 2), vi + (2 - i % 2)}
+            // We change first and second indices for Unity
+
+            int triangleIndex = i / 3;
+            switch(i % 3)
+            {
+                case 0:
+                    result[i] = triangleIndex + (1 + triangleIndex % 2);
+                    break;
+                case 1:
+                    result[i] = triangleIndex;
+                    break;
+                case 2:
+                    result[i] = triangleIndex + (2 - triangleIndex % 2);
+                    break;
+            }
+        }
+    }
+
+    [BurstCompile]
+    unsafe struct CreateIndicesForTriangleFanJob : IJobParallelFor
+    {
+
+        [ReadOnly]
+        [NativeDisableUnsafePtrRestriction]
+        public int* result;
+
+        public void Execute(int i)
+        {
+            // Source https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html
+            // Triangle Fans
+            // Triangle primitives are defined around a shared common vertex, according to the equation:
+            // pi = {vi+1, vi+2, v0}
+            // We change first and second indices for Unity
+
+            int triangleIndex = i / 3;
+            switch (i % 3)
+            {
+                case 0:
+                    result[i] = triangleIndex + 2;
+                    break;
+                case 1:
+                    result[i] = triangleIndex + 1;
+                    break;
+                case 2:
+                    result[i] = 0;
+                    break;
+            }
+        }
+    }
+
+    [BurstCompile]
+    unsafe struct RecalculateIndicesForTriangleStripJob : IJobParallelFor
+    {
+        [ReadOnly]
+        [NativeDisableUnsafePtrRestriction]
+        public int* input;
+
+        [ReadOnly]
+        [NativeDisableUnsafePtrRestriction]
+        public int* result;
+
+        public void Execute(int i)
+        {
+            // Source https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html
+            // Triangle Strips
+            // One triangle primitive is defined by each vertex and the two vertices that follow it, according to the equation:
+            // pi = { vi, vi + (1 + i % 2), vi + (2 - i % 2)}
+            // We change first and second indices for Unity
+
+            int triangleIndex = i * 3;
+            result[triangleIndex + 1] = input[i];
+            result[triangleIndex] = input[i + (1 + i % 2)];
+            result[triangleIndex + 2] = input[i + (2 - i % 2)];
+        }
+    }
+
+    [BurstCompile]
+    unsafe struct RecalculateIndicesForTriangleFanJob : IJobParallelFor
+    {
+        [ReadOnly]
+        [NativeDisableUnsafePtrRestriction]
+        public int* input;
+
+        [ReadOnly]
+        [NativeDisableUnsafePtrRestriction]
+        public int* result;
+
+        public void Execute(int i)
+        {
+            // Source https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html
+            // Triangle Fans
+            // Triangle primitives are defined around a shared common vertex, according to the equation:
+            // pi = {vi+1, vi+2, v0}
+            // We change first and second indices for Unity
+
+            int triangleIndex = i * 3;
+            result[triangleIndex + 1] = input[i+1];
+            result[triangleIndex] = input[i+2];
+            result[triangleIndex + 2] = 0;
+        }
+    }
+    [BurstCompile]
     unsafe struct ConvertIndicesUInt8ToInt32Job : IJobParallelFor
     {
 


### PR DESCRIPTION
According to these two issues;

- https://github.com/atteneder/glTFast/issues/316
- https://github.com/atteneder/glTFast/issues/689

These primitive modes are not implemented:
- `TRIANGLE_STRIP`
- `TRIANGLE_FAN`

And this primitive mode is not rendered correctly:
- `LINE_LOOP`

### **`TRIANGLE_STRIP` and `TRIANGLE_FAN` implementation**
First of all, we need example assets for the two primitive mode implementations (`TRIANGLE_STRIP`, `TRIANGLE_FAN`)
We can find those assets from these two links;
- https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/MeshPrimitiveModes
- https://github.com/KhronosGroup/glTF-Asset-Generator/tree/main/Output/Positive/Mesh_PrimitiveMode

First link includes a gltf file with all the primitive modes embedded in one file. Second one has seperate gltf files where each one is a different primitive mode.

In order to correctly implement these triangle primitive modes gltf-2.0 specification documentation of Khronos Group was used;
- https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html

From this documentation these two formulas was used;

Triangle Strips
One triangle primitive is defined by each vertex and the two vertices that follow it, according to the equation:
- pi = {vi, vi+(1+i%2), vi+(2-i%2)}

Triangle Fans
Triangle primitives are defined around a shared common vertex, according to the equation:
- pi = {vi+1, vi+2, v0}

Since it was necessary to create the indices from scratch this change was necessary;
before
```
var usage = (
    primitive.mode == DrawMode.Triangles
    || primitive.mode == DrawMode.TriangleStrip
    || primitive.mode == DrawMode.TriangleFan
    )
? AccessorUsage.IndexFlipped
: AccessorUsage.Index;
```
after
```
var usage = ( primitive.mode == DrawMode.Triangles )
? AccessorUsage.IndexFlipped
: AccessorUsage.Index;
```


In order to check if the results was correct gltf viewer of Khronos group was used;
- https://github.khronos.org/glTF-Sample-Viewer-Release/

Since I couldn't find any other example assets I used blender to generate them. These are the steps to do so;
- Import or draw any shape in Blender (I used Blender 4.2)
- Export using gltf seperate option
- Add primitive mode to the glft file (or change the existing from 4 `TRIANGLE` to 5 `TRIANGLE_STRIP` or 6 `TRIANGLE_FAN`)
- Import the asset to Unity and gltf viewer of Khronos group, and compare them
- The results were looking the same even though the topology was messed up

I am not sure if using blender was correct way to check that but the original assets were correctly imported.

### **`LINE_LOOP` render display fix**

As stated in the issue it was needed to add one more index to the end of the original index list. In line 3661 `Array.Copy` was used (I don't know if Job system was supposed to be used here too)

Unity version 2022.3.38f1 was used in this PR