### PR TITLE
Fixed link to the code of conduct

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ original creation and that you have complete right and authority to make your
 contributions. We allow both individual contributions and contributions made on
 behalf of companies.
 
-[COC]: (CODE_OF_CONDUCT.md)
+[COC]: CODE_OF_CONDUCT.md
 [Git]: https://git-scm.com/
 [repo]: https://github.com/Unity-Technologies/com.unity.cloud.gltfast
 [issues]: https://github.com/Unity-Technologies/com.unity.cloud.gltfast/issues


### PR DESCRIPTION
The link in the CONTRIBUTING.md file to CODE_OF_CONDUCT.md throws 404 error. This pr includes a fix to that.

I am not sure if it was supposed to be like this but when viewing the file in github.com the error occurs.