### PR TITLE
Fix Synchronization Context not resetting after exception

### DIFF
--- a/Packages/com.unity.cloud.gltfast/Editor/Scripts/AsyncHelpers.cs
+++ b/Packages/com.unity.cloud.gltfast/Editor/Scripts/AsyncHelpers.cs
@@ -20,25 +20,32 @@ namespace GLTFast.Utils
             var sync = new ExclusiveSynchronizationContext();
             SynchronizationContext.SetSynchronizationContext(sync);
             // ReSharper disable once AsyncVoidLambda
-            sync.Post(async _ =>
+            try
             {
-                try
+                sync.Post(async _ =>
                 {
-                    await task();
-                }
-                catch (Exception e)
-                {
-                    sync.InnerException = e;
-                    throw;
-                }
-                finally
-                {
-                    sync.EndMessageLoop();
-                }
-            }, null);
-            sync.BeginMessageLoop();
-
-            SynchronizationContext.SetSynchronizationContext(oldContext);
+                    try
+                    {
+                        await task();
+                    }
+                    catch (Exception e)
+                    {
+                        sync.InnerException = e;
+                        throw;
+                    }
+                    finally
+                    {
+                        sync.EndMessageLoop();
+                    }
+                }, null);
+                
+                sync.BeginMessageLoop();
+            }
+            finally
+            {
+                // Always restore the old context, even if there's an exception
+                SynchronizationContext.SetSynchronizationContext(oldContext);
+            }
         }
 
         /// <summary>
@@ -54,24 +61,32 @@ namespace GLTFast.Utils
             SynchronizationContext.SetSynchronizationContext(sync);
             T ret = default(T);
             // ReSharper disable once AsyncVoidLambda
-            sync.Post(async _ =>
+            try
             {
-                try
+                sync.Post(async _ =>
                 {
-                    ret = await task();
-                }
-                catch (Exception e)
-                {
-                    sync.InnerException = e;
-                    throw;
-                }
-                finally
-                {
-                    sync.EndMessageLoop();
-                }
-            }, null);
-            sync.BeginMessageLoop();
-            SynchronizationContext.SetSynchronizationContext(oldContext);
+                    try
+                    {
+                        ret = await task();
+                    }
+                    catch (Exception e)
+                    {
+                        sync.InnerException = e;
+                        throw;
+                    }
+                    finally
+                    {
+                        sync.EndMessageLoop();
+                    }
+                }, null);
+
+                sync.BeginMessageLoop();
+            }
+            finally
+            {
+                // Always restore the old context, even if there's an exception
+                SynchronizationContext.SetSynchronizationContext(oldContext);
+            }
             return ret;
         }
 


### PR DESCRIPTION
**Description**

This pull request fixes an issue where `RunSync(Func<Task>)` might not restore the original SynchronizationContext after encountering an exception. The solution ensures the context is restored in a try/finally block so that Unity’s default context is never left in a corrupted state.

In my particular case, I had a bad glb file causing it to throw an exception during asset importing and making all my async tests fail (timeout) on my CI/CD setup since the SynchronizationContext was still `ExclusiveSynchronizationContext` when the tests started, caused by the exception that never restored Unity's default context.

**Solution**
- Use a try/finally block so `SynchronizationContext.SetSynchronizationContext(oldContext)` always runs.
- No functional changes otherwise.

It's worth noting that I've tried re-using the original `finally` clause, restoring the original context after (or before) `sync.EndMessageLoop()`, but that does not work since `sync.EndMessageLoop()` itself would trigger the context to switch back to `ExclusiveSynchronizationContext` regardless if I tried to do it before or after the call to `sync.EndMessageLoop()`.

**Before the fix**

`ExclusiveSynchronizationContext` will be wrongly carried to the next asset as its `oldContext` as `SynchronizationContext.SetSynchronizationContext(oldContext)` is not called during an exception, making Unity's context to never be restored again in a headless CI/CD machine:

<img width="773" alt="problem" src="https://github.com/user-attachments/assets/a0d4ae00-3c47-499d-9c75-30b699ef0261" />


**After the fix**

Unity context is restored after the exception:

<img width="1490" alt="fix" src="https://github.com/user-attachments/assets/806c02a0-470b-434b-b244-2bd7b3b6ad5b" />
