### PR TITLE
fix: Fixed racing issues on results of vertex colors and bones jobs.

### DIFF
--- a/Packages/com.unity.cloud.gltfast/Runtime/Scripts/Jobs.cs
+++ b/Packages/com.unity.cloud.gltfast/Runtime/Scripts/Jobs.cs
@@ -1026,7 +1026,8 @@ namespace GLTFast.Jobs
         public byte* input;
 
         [WriteOnly]
-        public NativeSlice<float4> result;
+        [NativeDisableUnsafePtrRestriction]
+        public float4* result;
 
         public void Execute(int i)
         {
@@ -1050,7 +1051,8 @@ namespace GLTFast.Jobs
         public ushort* input;
 
         [WriteOnly]
-        public NativeSlice<float4> result;
+        [NativeDisableUnsafePtrRestriction]
+        public float4* result;
 
         public void Execute(int i)
         {
@@ -1164,7 +1166,8 @@ namespace GLTFast.Jobs
         public byte* input;
 
         [WriteOnly]
-        public NativeSlice<float4> result;
+        [NativeDisableUnsafePtrRestriction]
+        public float4* result;
 
         public void Execute(int i)
         {
@@ -2323,10 +2326,11 @@ namespace GLTFast.Jobs
     }
 
     [BurstCompile]
-    struct SortAndNormalizeBoneWeightsJob : IJobParallelFor
+    unsafe struct SortAndNormalizeBoneWeightsJob : IJobParallelFor
     {
 
-        public NativeArray<VBones> bones;
+        [NativeDisableUnsafePtrRestriction]
+        public VBones* bones;
 
         /// <summary>
         /// Number of skin weights that are taken into account (project quality setting)
@@ -2408,9 +2412,10 @@ namespace GLTFast.Jobs
 
 #if GLTFAST_SAFE
     [BurstCompile]
-    struct RenormalizeBoneWeightsJob : IJobParallelFor {
+    unsafe struct RenormalizeBoneWeightsJob : IJobParallelFor {
 
-        public NativeArray<VBones> bones;
+        [NativeDisableUnsafePtrRestriction]
+        public VBones* bones;
 
         public unsafe void Execute(int index) {
             var v = bones[index];

--- a/Packages/com.unity.cloud.gltfast/Runtime/Scripts/VertexBufferColors.cs
+++ b/Packages/com.unity.cloud.gltfast/Runtime/Scripts/VertexBufferColors.cs
@@ -48,7 +48,8 @@ namespace GLTFast
                 colorAcc.componentType,
                 colorAcc.GetAttributeType(),
                 byteStride,
-                m_Data.Slice(offset, colorAcc.count)
+                colorAcc.count,
+                (float4*)((byte*)m_Data.GetUnsafePtr() + offset * sizeof(float4))
             );
             if (h.HasValue)
             {
@@ -92,7 +93,8 @@ namespace GLTFast
             GltfComponentType inputType,
             GltfAccessorAttributeType attributeType,
             int inputByteStride,
-            NativeSlice<float4> output
+            int count,
+            float4* output
             )
         {
             Profiler.BeginSample("PrepareColors32");
@@ -110,7 +112,7 @@ namespace GLTFast
                                 inputByteStride = inputByteStride > 0 ? inputByteStride : 3,
                                 result = output
                             };
-                            jobHandle = job.Schedule(output.Length, GltfImport.DefaultBatchCount);
+                            jobHandle = job.Schedule(count, GltfImport.DefaultBatchCount);
                         }
                         break;
                     case GltfComponentType.Float:
@@ -119,9 +121,9 @@ namespace GLTFast
                             {
                                 input = (byte*)input,
                                 inputByteStride = inputByteStride > 0 ? inputByteStride : 12,
-                                result = (float4*)output.GetUnsafePtr()
+                                result = output
                             };
-                            jobHandle = job.Schedule(output.Length, GltfImport.DefaultBatchCount);
+                            jobHandle = job.Schedule(count, GltfImport.DefaultBatchCount);
                         }
                         break;
                     case GltfComponentType.UnsignedShort:
@@ -132,7 +134,7 @@ namespace GLTFast
                                 inputByteStride = inputByteStride > 0 ? inputByteStride : 6,
                                 result = output
                             };
-                            jobHandle = job.Schedule(output.Length, GltfImport.DefaultBatchCount);
+                            jobHandle = job.Schedule(count, GltfImport.DefaultBatchCount);
                         }
                         break;
                     default:
@@ -152,7 +154,7 @@ namespace GLTFast
                                 inputByteStride = inputByteStride > 0 ? inputByteStride : 4,
                                 result = output
                             };
-                            jobHandle = job.Schedule(output.Length, GltfImport.DefaultBatchCount);
+                            jobHandle = job.Schedule(count, GltfImport.DefaultBatchCount);
                         }
                         break;
                     case GltfComponentType.Float:
@@ -161,9 +163,9 @@ namespace GLTFast
                             {
                                 var job = new Jobs.MemCopyJob
                                 {
-                                    bufferSize = output.Length * 16,
+                                    bufferSize = count * 16,
                                     input = input,
-                                    result = output.GetUnsafeReadOnlyPtr()
+                                    result = output
                                 };
                                 jobHandle = job.Schedule();
                             }
@@ -173,12 +175,12 @@ namespace GLTFast
                                 {
                                     input = (byte*)input,
                                     inputByteStride = inputByteStride,
-                                    result = (float4*)output.GetUnsafePtr()
+                                    result = output
                                 };
 #if UNITY_COLLECTIONS
-                                jobHandle = job.ScheduleBatch(output.Length,GltfImport.DefaultBatchCount);
+                                jobHandle = job.ScheduleBatch(count,GltfImport.DefaultBatchCount);
 #else
-                                jobHandle = job.Schedule(output.Length, GltfImport.DefaultBatchCount);
+                                jobHandle = job.Schedule(count, GltfImport.DefaultBatchCount);
 #endif
                             }
                         }
@@ -189,12 +191,12 @@ namespace GLTFast
                             {
                                 input = (ushort*)input,
                                 inputByteStride = inputByteStride > 0 ? inputByteStride : 8,
-                                result = (float4*)output.GetUnsafePtr()
+                                result = output
                             };
 #if UNITY_COLLECTIONS
-                            jobHandle = job.ScheduleBatch(output.Length,GltfImport.DefaultBatchCount);
+                            jobHandle = job.ScheduleBatch(count,GltfImport.DefaultBatchCount);
 #else
-                            jobHandle = job.Schedule(output.Length, GltfImport.DefaultBatchCount);
+                            jobHandle = job.Schedule(count, GltfImport.DefaultBatchCount);
 #endif
                         }
                         break;


### PR DESCRIPTION
Fixes racing issues with vertex colored or skinned models that have submeshes.

Loading this model will currently give two errors and abort the load.
Model: [SkinnedVertexColor.zip](https://github.com/user-attachments/files/19737695/SkinnedVertexColor.zip)
Preview:
![image](https://github.com/user-attachments/assets/05197dac-4035-4eee-941b-9537f88ac18f)


Platform: Windows, Editor, Runtime loading


Bones issue:
```
InvalidOperationException: The previously scheduled job RenormalizeBoneWeightsJob writes to the Unity.Collections.NativeArray`1[GLTFast.Vertex.VBones] RenormalizeBoneWeightsJob.bones. You must call JobHandle.Complete() on the job RenormalizeBoneWeightsJob, before you can read from the Unity.Collections.NativeArray`1[GLTFast.Vertex.VBones] safely.
Unity.Collections.LowLevel.Unsafe.AtomicSafetyHandle.CheckReadAndThrowNoEarlyOut (Unity.Collections.LowLevel.Unsafe.AtomicSafetyHandle handle) (at <fc22648a2f8c48a38d6136ea0e187002>:0)
Unity.Collections.LowLevel.Unsafe.AtomicSafetyHandle.CheckReadAndThrow (Unity.Collections.LowLevel.Unsafe.AtomicSafetyHandle handle) (at <fc22648a2f8c48a38d6136ea0e187002>:0)
Unity.Collections.LowLevel.Unsafe.NativeArrayUnsafeUtility.GetUnsafeReadOnlyPtr[T] (Unity.Collections.NativeArray`1[T] nativeArray) (at <fc22648a2f8c48a38d6136ea0e187002>:0)
GLTFast.VertexBufferBones.ScheduleVertexBonesJob (System.Int32 weightsAccessorIndex, System.Int32 jointsAccessorIndex, System.Int32 offset, GLTFast.IGltfBuffers buffers) (at ./Packages/glTFast/Packages/com.unity.cloud.gltfast/Runtime/Scripts/VertexBufferBones.cs:47)
GLTFast.VertexBufferGenerator`1[TMainBuffer].ScheduleVertexBonesJobs (GLTFast.Schema.Attributes att, System.Int32 i, Unity.Collections.NativeArray`1[T] handles, System.Int32 handleIndex) (at ./Packages/glTFast/Packages/com.unity.cloud.gltfast/Runtime/Scripts/VertexBufferGenerator.cs:373)
GLTFast.VertexBufferGenerator`1[TMainBuffer].CreateVertexBuffer () (at ./Packages/glTFast/Packages/com.unity.cloud.gltfast/Runtime/Scripts/VertexBufferGenerator.cs:192)
GLTFast.MeshGenerator.GenerateMesh (GLTFast.GltfImportBase gltfImport) (at ./Packages/glTFast/Packages/com.unity.cloud.gltfast/Runtime/Scripts/MeshGenerator.cs:189)
Rethrow as AggregateException: One or more errors occurred. (The previously scheduled job Renormaliz
```

Vertex Color issue:
```
InvalidOperationException: The previously scheduled job ConvertColorsRgbaUInt8ToRGBAFloatJob writes to the Unity.Collections.NativeArray`1[Unity.Mathematics.float4] ConvertColorsRgbaUInt8ToRGBAFloatJob.result. You are trying to schedule a new job ConvertColorsRgbaUInt8ToRGBAFloatJob, which writes to the same Unity.Collections.NativeArray`1[Unity.Mathematics.float4] (via ConvertColorsRgbaUInt8ToRGBAFloatJob.result). To guarantee safety, you must include ConvertColorsRgbaUInt8ToRGBAFloatJob as a dependency of the newly scheduled job.
Unity.Jobs.LowLevel.Unsafe.JobsUtility.ScheduleParallelFor (Unity.Jobs.LowLevel.Unsafe.JobsUtility+JobScheduleParameters& parameters, System.Int32 arrayLength, System.Int32 innerloopBatchCount) (at <fc22648a2f8c48a38d6136ea0e187002>:0)
Unity.Jobs.IJobParallelForExtensions.Schedule[T] (T jobData, System.Int32 arrayLength, System.Int32 innerloopBatchCount, Unity.Jobs.JobHandle dependsOn) (at <fc22648a2f8c48a38d6136ea0e187002>:0)
GLTFast.VertexBufferColors.GetColors32Job (System.Void* input, GLTFast.Schema.GltfComponentType inputType, GLTFast.Schema.GltfAccessorAttributeType attributeType, System.Int32 inputByteStride, Unity.Collections.NativeSlice`1[T] output) (at ./Packages/glTFast/Packages/com.unity.cloud.gltfast/Runtime/Scripts/VertexBufferColors.cs:155)
GLTFast.VertexBufferColors.ScheduleVertexColorJob (System.Int32 colorAccessorIndex, System.Int32 offset, Unity.Collections.NativeSlice`1[T] handles, GLTFast.IGltfBuffers buffers) (at ./Packages/glTFast/Packages/com.unity.cloud.gltfast/Runtime/Scripts/VertexBufferColors.cs:46)
GLTFast.VertexBufferGenerator`1[TMainBuffer].ScheduleColorsJobs (GLTFast.Schema.Attributes att, System.Int32 i, Unity.Collections.NativeArray`1[T] handles, System.Int32& handleIndex) (at ./Packages/glTFast/Packages/com.unity.cloud.gltfast/Runtime/Scripts/VertexBufferGenerator.cs:356)
```

The cause is trying to reuse the results NativeArray for multiple submeshes, without having the previous job as a dependency.

These changes fixes that. As the submeshes always write to different parts of the NativeArray, I decided to use pointers directly similar to the other vertex jobs instead of adding dependencies to previous job handles.

A semi-related issue is having vertex colors on a skinned model gives this warning:
```
Skinned mesh attributes use wrong streams: TexCoord0 should use stream 1 (was 2), TexCoord1 should use stream 1 (was 2), TexCoord2 should use stream 1 (was 2), TexCoord3 should use stream 1 (was 2), TexCoord4 should use stream 1 (was 2), TexCoord5 should use stream 1 (was 2), TexCoord6 should use stream 1 (was 2), TexCoord7 should use stream 1 (was 2), BlendWeight should use stream 2 (was 3), BlendIndices should use stream 2 (was 3)
UnityEngine.Mesh:SetVertexBufferParams (int,UnityEngine.Rendering.VertexAttributeDescriptor[])
GLTFast.VertexBufferGenerator`1<GLTFast.Vertex.VPosNorm>:ApplyOnMesh (UnityEngine.Mesh,UnityEngine.Rendering.MeshUpdateFlags) (at ./Packages/glTFast/Packages/com.unity.cloud.gltfast/Runtime/Scripts/VertexBufferGenerator.cs:448)
```

It still loads fine, but I guess the warning means Unity is doing some extra work behind the scene to fix the streams. I tried to fix it, but couldn't find a solution to that. The same model can be use for testing this issue.




