### PR TITLE
Add OnBeforeDisposeVolatileData method

### DIFF
--- a/Packages/com.unity.cloud.gltfast/Runtime/Scripts/GltfImport.cs
+++ b/Packages/com.unity.cloud.gltfast/Runtime/Scripts/GltfImport.cs
@@ -3087,10 +3087,19 @@ namespace GLTFast
         }
 
         /// <summary>
+        /// Called at the beginning of <see cref="DisposeVolatileData"/> before buffers are freed.
+        /// Override to process import addon instances while data is still accessible.
+        /// </summary>
+        /// <param name="importInstances">The import addon instances dictionary, may be null.</param>
+        protected virtual void OnBeforeDisposeVolatileData(Dictionary<Type, ImportAddonInstance> importInstances) { }
+
+        /// <summary>
         /// Free up volatile loading resources
         /// </summary>
         async Task DisposeVolatileData()
         {
+            OnBeforeDisposeVolatileData(m_ImportInstances);
+
             m_Buffers = null;
             m_BinChunks = null;
 

--- a/Packages/com.unity.cloud.gltfast/Runtime/Scripts/GltfImport.cs
+++ b/Packages/com.unity.cloud.gltfast/Runtime/Scripts/GltfImport.cs
@@ -3088,17 +3088,16 @@ namespace GLTFast
 
         /// <summary>
         /// Called at the beginning of <see cref="DisposeVolatileData"/> before buffers are freed.
-        /// Override to process import addon instances while data is still accessible.
+        /// Override to process data while it is still accessible.
         /// </summary>
-        /// <param name="importInstances">The import addon instances dictionary, may be null.</param>
-        protected virtual void OnBeforeDisposeVolatileData(Dictionary<Type, ImportAddonInstance> importInstances) { }
+        protected virtual void OnBeforeDisposeVolatileData() { }
 
         /// <summary>
         /// Free up volatile loading resources
         /// </summary>
         async Task DisposeVolatileData()
         {
-            OnBeforeDisposeVolatileData(m_ImportInstances);
+            OnBeforeDisposeVolatileData();
 
             m_Buffers = null;
             m_BinChunks = null;


### PR DESCRIPTION
I was working on adding support to read custom vertex attributes for vertices as an add-on and if I understand the structure correct, I need the buffer information before it got disposed, to be able to read data. This method fires after data is loaded but before it's disposed.
About the usage; I have a custom `GltfImport` class, which overrides this new `OnBeforeDisposeVolatileData` method, then uses `GetImportAddonInstance` method to find my custom add-on and class a `OnLoadCompleted` method in it. Add-on uses accessor data, decodes it and caches the colors. later when `OnMeshAdded` is called, it applies the extracted data to the mesh.
Can't say I extensively tested my add-on and system built on top of this but it seems to work fine so far. I can also share those if you want to examine the use-case but they are not included into the PR of course.