### PR TITLE
Fixed export summary misplaced commas

### DIFF
--- a/Packages/com.unity.cloud.gltfast/Runtime/Scripts/Export/GltfWriter.cs
+++ b/Packages/com.unity.cloud.gltfast/Runtime/Scripts/Export/GltfWriter.cs
@@ -734,9 +734,9 @@ namespace GLTFast.Export
             sb.AppendFormat("{0} bytes JSON + {1} bytes buffer", jsonLength, bufferLength);
             if (m_Gltf != null) {
                 sb.AppendFormat(", {0} nodes", m_Gltf.Nodes?.Count ?? 0);
-                sb.AppendFormat(" ,{0} meshes", m_Gltf.meshes?.Length ?? 0);
-                sb.AppendFormat(" ,{0} materials", m_Gltf.Materials?.Count ?? 0);
-                sb.AppendFormat(" ,{0} images", m_Gltf.Images?.Count ?? 0);
+                sb.AppendFormat(", {0} meshes", m_Gltf.meshes?.Length ?? 0);
+                sb.AppendFormat(", {0} materials", m_Gltf.Materials?.Count ?? 0);
+                sb.AppendFormat(", {0} images", m_Gltf.Images?.Count ?? 0);
             }
             m_Logger?.Info(sb.ToString());
 #endif


### PR DESCRIPTION
When exporting a glb, the summary has strange comma placement that bug me.

Before:
<img width="634" height="96" alt="image" src="https://github.com/user-attachments/assets/65a9ed74-4786-45a6-9bbe-8b660b530450" />

With this PR:
<img width="650" height="102" alt="image" src="https://github.com/user-attachments/assets/a8ab2f1d-5143-4b09-8c54-ff0794e8b7c6" />
